### PR TITLE
fix: use exec instead of ado plugin for semantic-release, resolve lint issues

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -17,6 +17,8 @@ jobs:
       contents: write
       id-token: write
     runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || format('codebuild-aigerimzhalgasbekova-auth-api-{0}-{1}', github.run_id, github.run_attempt) }}
+    outputs:
+      Version: ${{ steps.semantic-release.outputs.Version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -36,6 +38,7 @@ jobs:
         run: |
           npm ci
           npx semantic-release
+          echo "Version=$Version" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Build Lambda packages

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -12,7 +12,5 @@ plugins:
         - type: 'chore'
           release: 'patch'
   - '@semantic-release/release-notes-generator'
-  - - 'semantic-release-ado'
-    - varName: "Version"
-      setOnlyOnRelease: true
-      isOutput: true
+  - - '@semantic-release/exec'
+    - verifyReleaseCmd: echo "Version=${nextRelease.version}" >> $GITHUB_ENV

--- a/cdk/lib/echo-api-stack.ts
+++ b/cdk/lib/echo-api-stack.ts
@@ -44,29 +44,34 @@ export class EchoApiStack extends cdk.Stack {
                 artifactBucket,
                 `${props.serviceName}/authorizer-${props.version}.zip`,
             );
-            echoCode = lambda.Code.fromBucket(artifactBucket, `${props.serviceName}/echo-${props.version}.zip`);
+            echoCode = lambda.Code.fromBucket(
+                artifactBucket,
+                `${props.serviceName}/echo-${props.version}.zip`,
+            );
         }
 
         // Create IAM role for the Authorizer function
         const authorizerRole = new iam.Role(this, 'AuthorizerRole', {
             assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
             managedPolicies: [
-                iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaVPCAccessExecutionRole'),
-                iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaBasicExecutionRole'),
+                iam.ManagedPolicy.fromAwsManagedPolicyName(
+                    'service-role/AWSLambdaVPCAccessExecutionRole',
+                ),
+                iam.ManagedPolicy.fromAwsManagedPolicyName(
+                    'service-role/AWSLambdaBasicExecutionRole',
+                ),
             ],
             inlinePolicies: {
-                'KmsKeyAccess': new iam.PolicyDocument({
+                KmsKeyAccess: new iam.PolicyDocument({
                     statements: [
                         new iam.PolicyStatement({
                             effect: iam.Effect.ALLOW,
-                            actions: [
-                                'kms:Verify',
-                            ],
-                            resources: [props.jwtSigningKey.keyArn]
-                        })
-                    ]
+                            actions: ['kms:Verify'],
+                            resources: [props.jwtSigningKey.keyArn],
+                        }),
+                    ],
                 }),
-            }
+            },
         });
 
         // Create Lambda functions
@@ -87,8 +92,12 @@ export class EchoApiStack extends cdk.Stack {
         const echoRole = new iam.Role(this, 'EchoRole', {
             assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
             managedPolicies: [
-                iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaVPCAccessExecutionRole'),
-                iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaBasicExecutionRole'),
+                iam.ManagedPolicy.fromAwsManagedPolicyName(
+                    'service-role/AWSLambdaVPCAccessExecutionRole',
+                ),
+                iam.ManagedPolicy.fromAwsManagedPolicyName(
+                    'service-role/AWSLambdaBasicExecutionRole',
+                ),
             ],
         });
 

--- a/cdk/lib/token-issuer-stack.ts
+++ b/cdk/lib/token-issuer-stack.ts
@@ -34,7 +34,10 @@ export class TokenIssuerStack extends cdk.Stack {
 
         // Create DynamoDB table for storing existing users information
         const tokenTable = new dynamodb.Table(this, 'TokenTable', {
-            partitionKey: { name: 'Username', type: dynamodb.AttributeType.STRING },
+            partitionKey: {
+                name: 'Username',
+                type: dynamodb.AttributeType.STRING,
+            },
             sortKey: { name: 'Password', type: dynamodb.AttributeType.STRING },
             billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
             encryption: dynamodb.TableEncryption.AWS_MANAGED,
@@ -66,34 +69,33 @@ export class TokenIssuerStack extends cdk.Stack {
         const authTokenIssuerRole = new iam.Role(this, 'AuthTokenIssuerRole', {
             assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
             managedPolicies: [
-                iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaVPCAccessExecutionRole'),
-                iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaBasicExecutionRole'),
+                iam.ManagedPolicy.fromAwsManagedPolicyName(
+                    'service-role/AWSLambdaVPCAccessExecutionRole',
+                ),
+                iam.ManagedPolicy.fromAwsManagedPolicyName(
+                    'service-role/AWSLambdaBasicExecutionRole',
+                ),
             ],
             inlinePolicies: {
-                'TokenTableAccess': new iam.PolicyDocument({
+                TokenTableAccess: new iam.PolicyDocument({
                     statements: [
                         new iam.PolicyStatement({
                             effect: iam.Effect.ALLOW,
-                            actions: [
-                                'dynamodb:Query',
-                                'dynamodb:GetItem',
-                            ],
-                            resources: [tokenTable.tableArn]
-                        })
-                    ]
+                            actions: ['dynamodb:Query', 'dynamodb:GetItem'],
+                            resources: [tokenTable.tableArn],
+                        }),
+                    ],
                 }),
-                'KmsKeyAccess': new iam.PolicyDocument({
+                KmsKeyAccess: new iam.PolicyDocument({
                     statements: [
                         new iam.PolicyStatement({
                             effect: iam.Effect.ALLOW,
-                            actions: [
-                                'kms:Sign',
-                            ],
-                            resources: [this.jwtSigningKey.keyArn]
-                        })
-                    ]
+                            actions: ['kms:Sign'],
+                            resources: [this.jwtSigningKey.keyArn],
+                        }),
+                    ],
                 }),
-            }
+            },
         });
 
         // Create Lambda function


### PR DESCRIPTION
This PR includes:
- fix build output, use exec instead of ado to create Version variable, and then output Version in build job;
- fix lint issues in echo-api-stack and token-issuer-stack.